### PR TITLE
Use team keys for authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ files:
           token: ${{ secrets.PAT_FOR_AUTO_REQUEST_REVIEW }}
 ```
 
+### Working with Forks
+
+By default, forks do not have `write` access or permissions with workflows. However, for workflows that need `write` access to do menial tasks like make comments or add reviewers, the `pull_request_target` trigger can be used. This trigger gives forks `write` access for the workflows. You can read more about the [`pull_request_target` trigger here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).
+
+The `pull_request_target` trigger works for both native branches as well as forks.
+
+```yaml
+name: Auto Request Review
+
+on:
+  pull_request_target:
+```
+
 #### Dependabot compatibility
 
 Note that with the [recent change to GitHub Actions that are created by Dependabot](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), the `pull_request` event will no longer give access to your secrets to this action. Instead you will need to use the `pull_request_target` event. If you do this make sure to read [Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) to understand the risks involved.

--- a/dist/index.js
+++ b/dist/index.js
@@ -16025,7 +16025,7 @@ async function get_team_members(team) {
   return octokit.teams.listMembersInOrg({
     org: context.repo.org,
     team_slug: team,
-  })?.map((member) => member.login)
+  })?.map((member) => member.login);
 }
 
 /* Private */

--- a/dist/index.js
+++ b/dist/index.js
@@ -16017,6 +16017,17 @@ async function assign_reviewers(reviewers) {
   });
 }
 
+// https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#list-team-members
+async function get_team_members(team) {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  return octokit.teams.listMembersInOrg({
+    org: context.repo.org,
+    team_slug: team,
+  })?.map((member) => member.login)
+}
+
 /* Private */
 
 let context_cache;
@@ -16063,6 +16074,7 @@ module.exports = {
   fetch_changed_files,
   assign_reviewers,
   clear_cache,
+  get_team_members,
 };
 
 
@@ -16170,6 +16182,7 @@ if (process.env.NODE_ENV !== 'automated-testing') {
 const core = __nccwpck_require__(2186);
 const minimatch = __nccwpck_require__(3973);
 const sample_size = __nccwpck_require__(2199);
+const github = __nccwpck_require__(8396); // Don't destructure this object to stub with sinon in tests
 
 function fetch_other_group_members({ author, config }) {
   const DEFAULT_OPTIONS = {
@@ -16242,6 +16255,14 @@ function identify_reviewers_by_author({ config, 'author': specified_author }) {
   const matching_authors = Object.keys(config.reviewers.per_author).filter((author) => {
     if (author === specified_author) {
       return true;
+    }
+
+    if (author.startsWith('team:')) {
+      const team = author.replace('team:', '');
+      const individuals_in_team = github.get_team_members(team);
+      if (individuals_in_team.includes(specified_author)) {
+        return true;
+      }
     }
 
     const individuals_in_author_setting = replace_groups_with_individuals({ reviewers: [ author ], config });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,13 +2075,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -2205,12 +2202,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "node_modules/mocha": {
       "version": "9.2.1",
@@ -5241,13 +5232,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "just-extend": {
       "version": "4.2.1",
@@ -5340,12 +5328,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "mocha": {
       "version": "9.2.1",

--- a/src/github.js
+++ b/src/github.js
@@ -120,7 +120,7 @@ async function get_team_members(team) {
   return octokit.teams.listMembersInOrg({
     org: context.repo.org,
     team_slug: team,
-  })?.map((member) => member.login);
+  })?.data?.map((member) => member.login);
 }
 
 /* Private */

--- a/src/github.js
+++ b/src/github.js
@@ -120,7 +120,7 @@ async function get_team_members(team) {
   return octokit.teams.listMembersInOrg({
     org: context.repo.org,
     team_slug: team,
-  })?.map((member) => member.login)
+  })?.map((member) => member.login);
 }
 
 /* Private */

--- a/src/github.js
+++ b/src/github.js
@@ -112,10 +112,12 @@ async function assign_reviewers(reviewers) {
   });
 }
 
+// https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#list-team-members
 async function get_team_members(team) {
   const context = get_context();
   const octokit = get_octokit();
 
+  console.log(context);
   return octokit.teams.listMembersInOrg({
     org: context.repo.org,
     team_slug: team,

--- a/src/github.js
+++ b/src/github.js
@@ -117,11 +117,10 @@ async function get_team_members(team) {
   const context = get_context();
   const octokit = get_octokit();
 
-  console.log(context);
   return octokit.teams.listMembersInOrg({
     org: context.repo.org,
     team_slug: team,
-  });
+  })?.map((member) => member.login)
 }
 
 /* Private */

--- a/src/reviewer.js
+++ b/src/reviewer.js
@@ -80,7 +80,7 @@ function identify_reviewers_by_author({ config, 'author': specified_author }) {
 
     if (author.startsWith('team:')) {
       const team = author.replace('team:', '');
-      const individuals_in_team = github.get_team_members(team);
+      const individuals_in_team = github.get_team_members(team)?.map((member) member.login);
       if (individuals_in_team.includes(specified_author)) {
         return true;
       }

--- a/src/reviewer.js
+++ b/src/reviewer.js
@@ -80,7 +80,7 @@ function identify_reviewers_by_author({ config, 'author': specified_author }) {
 
     if (author.startsWith('team:')) {
       const team = author.replace('team:', '');
-      const individuals_in_team = github.get_team_members(team)?.map((member) member.login);
+      const individuals_in_team = github.get_team_members(team);
       if (individuals_in_team.includes(specified_author)) {
         return true;
       }

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -177,7 +177,7 @@ describe('github', function() {
       expect(spy.calledOnce).to.be.true;
       expect(spy.lastCall.args[0]).to.deep.equal({
         org: 'necojackarc',
-        team_slug: 'koopa-troop'
+        team_slug: 'koopa-troop',
       });
     });
   });

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -138,16 +138,29 @@ describe('reviewer', function() {
           designers: [ 'mario', 'princess-peach', 'princess-daisy' ],
         },
         per_author: {
-          engineers: [ 'engineers', 'dr-mario' ],
-          designers: [ 'designers' ],
-          yoshi: [ 'mario', 'luige' ],
+          'engineers': [ 'engineers', 'dr-mario' ],
+          'designers': [ 'designers' ],
+          'yoshi': [ 'mario', 'luige' ],
           'team:koopa-troop': [ 'mario' ],
         },
       },
     };
 
     const stub = sinon.stub(github, 'get_team_members');
-    stub.withArgs('koopa-troop').returns([ 'bowser', 'king-boo', 'goomboss' ]);
+    stub.withArgs('koopa-troop').returns([
+      {
+        login: 'bowser',
+        id: 1,
+      },
+      {
+        login: 'king-boo',
+        id: 2,
+      },
+      {
+        login: 'goomboss',
+        id: 3,
+      },
+    ]);
 
     it('returns nothing when config does not have a "per-author" key', function() {
       const author = 'THIS DOES NOT MATTER';


### PR DESCRIPTION
It was not initially clear in README that `teams:{gh-team-name}` syntax was only used for reviewers. I tried using it for the `per_author` keys and it (obviously) didn't work. So I wrote this in so that it would work. If the PR author is in the `per_author` `team:{gh-team-name}` collection, use the respective reviewer for assignment.

```
reviewers:
  per_author:
    team:koopa-troop:
      - mario
```

For example, this configuration would assign reviewer `mario` when the PR author is in github team `koopa-troop`. 