### PR TITLE
Use pull_request_target on GitHub Actions to allow public forks to run CI without approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
     branches: ['**']
 
 jobs:


### PR DESCRIPTION
> Note: Workflows triggered by pull_request_target events are run in the context of the base branch. Since the base branch is considered trusted, workflows triggered by these events will always run, regardless of approval settings. For more information about the pull_request_target event, see "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)."

See https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks for more details.

Also, add Node v18 to the CI target.