### PR TITLE
Revert Use team keys for authors (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@ reviewers:
     designer_b:
       - lead_desinger # username
       - desinger_a # username
-    team:engineering-managers:
-      - engineers
 
 files:
   # Keys are glob expressions.

--- a/dist/index.js
+++ b/dist/index.js
@@ -16017,17 +16017,6 @@ async function assign_reviewers(reviewers) {
   });
 }
 
-// https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#list-team-members
-async function get_team_members(team) {
-  const context = get_context();
-  const octokit = get_octokit();
-
-  return octokit.teams.listMembersInOrg({
-    org: context.repo.org,
-    team_slug: team,
-  })?.data?.map((member) => member.login);
-}
-
 /* Private */
 
 let context_cache;
@@ -16074,7 +16063,6 @@ module.exports = {
   fetch_changed_files,
   assign_reviewers,
   clear_cache,
-  get_team_members,
 };
 
 
@@ -16182,7 +16170,6 @@ if (process.env.NODE_ENV !== 'automated-testing') {
 const core = __nccwpck_require__(2186);
 const minimatch = __nccwpck_require__(3973);
 const sample_size = __nccwpck_require__(2199);
-const github = __nccwpck_require__(8396); // Don't destructure this object to stub with sinon in tests
 
 function fetch_other_group_members({ author, config }) {
   const DEFAULT_OPTIONS = {
@@ -16255,14 +16242,6 @@ function identify_reviewers_by_author({ config, 'author': specified_author }) {
   const matching_authors = Object.keys(config.reviewers.per_author).filter((author) => {
     if (author === specified_author) {
       return true;
-    }
-
-    if (author.startsWith('team:')) {
-      const team = author.replace('team:', '');
-      const individuals_in_team = github.get_team_members(team);
-      if (individuals_in_team.includes(specified_author)) {
-        return true;
-      }
     }
 
     const individuals_in_author_setting = replace_groups_with_individuals({ reviewers: [ author ], config });

--- a/src/github.js
+++ b/src/github.js
@@ -112,17 +112,6 @@ async function assign_reviewers(reviewers) {
   });
 }
 
-// https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#list-team-members
-async function get_team_members(team) {
-  const context = get_context();
-  const octokit = get_octokit();
-
-  return octokit.teams.listMembersInOrg({
-    org: context.repo.org,
-    team_slug: team,
-  })?.data?.map((member) => member.login);
-}
-
 /* Private */
 
 let context_cache;
@@ -169,5 +158,4 @@ module.exports = {
   fetch_changed_files,
   assign_reviewers,
   clear_cache,
-  get_team_members,
 };

--- a/src/reviewer.js
+++ b/src/reviewer.js
@@ -3,7 +3,6 @@
 const core = require('@actions/core');
 const minimatch = require('minimatch');
 const sample_size = require('lodash/sampleSize');
-const github = require('./github'); // Don't destructure this object to stub with sinon in tests
 
 function fetch_other_group_members({ author, config }) {
   const DEFAULT_OPTIONS = {
@@ -76,14 +75,6 @@ function identify_reviewers_by_author({ config, 'author': specified_author }) {
   const matching_authors = Object.keys(config.reviewers.per_author).filter((author) => {
     if (author === specified_author) {
       return true;
-    }
-
-    if (author.startsWith('team:')) {
-      const team = author.replace('team:', '');
-      const individuals_in_team = github.get_team_members(team);
-      if (individuals_in_team.includes(specified_author)) {
-        return true;
-      }
     }
 
     const individuals_in_author_setting = replace_groups_with_individuals({ reviewers: [ author ], config });

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -14,7 +14,6 @@ const {
   fetch_changed_files,
   assign_reviewers,
   clear_cache,
-  get_team_members,
 } = require('../src/github');
 
 describe('github', function() {
@@ -153,31 +152,6 @@ describe('github', function() {
         team_reviewers: [
           'koopa-troop',
         ],
-      });
-    });
-  });
-
-  describe('get_team_members()', function() {
-    const spy = sinon.spy();
-    const octokit = {
-      teams: {
-        listMembersInOrg: spy,
-      },
-    };
-
-    beforeEach(function() {
-      github.getOctokit.resetBehavior();
-      github.getOctokit.returns(octokit);
-    });
-
-    it('gets team members', async function() {
-      const team = 'koopa-troop';
-      await get_team_members(team);
-
-      expect(spy.calledOnce).to.be.true;
-      expect(spy.lastCall.args[0]).to.deep.equal({
-        org: 'necojackarc',
-        team_slug: 'koopa-troop',
       });
     });
   });

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -10,9 +10,6 @@ const {
 } = require('../src/reviewer');
 const { expect } = require('chai');
 
-const github = require('../src/github');
-const sinon = require('sinon');
-
 describe('reviewer', function() {
   describe('fetch_other_group_members()', function() {
 
@@ -72,6 +69,7 @@ describe('reviewer', function() {
   });
 
   describe('identify_reviewers_by_changed_files()', function() {
+
     const config = {
       reviewers: {
         groups: {
@@ -138,29 +136,12 @@ describe('reviewer', function() {
           designers: [ 'mario', 'princess-peach', 'princess-daisy' ],
         },
         per_author: {
-          'engineers': [ 'engineers', 'dr-mario' ],
-          'designers': [ 'designers' ],
-          'yoshi': [ 'mario', 'luige' ],
-          'team:koopa-troop': [ 'mario' ],
+          engineers: [ 'engineers', 'dr-mario' ],
+          designers: [ 'designers' ],
+          yoshi: [ 'mario', 'luige' ],
         },
       },
     };
-
-    const stub = sinon.stub(github, 'get_team_members');
-    stub.withArgs('koopa-troop').returns([
-      {
-        login: 'bowser',
-        id: 1,
-      },
-      {
-        login: 'king-boo',
-        id: 2,
-      },
-      {
-        login: 'goomboss',
-        id: 3,
-      },
-    ]);
 
     it('returns nothing when config does not have a "per-author" key', function() {
       const author = 'THIS DOES NOT MATTER';
@@ -185,11 +166,6 @@ describe('reviewer', function() {
     it('works when the author belongs to more than one group', function() {
       const author = 'mario';
       expect(identify_reviewers_by_author({ config, author })).to.have.members([ 'dr-mario', 'luigi', 'wario', 'waluigi', 'princess-peach', 'princess-daisy' ]);
-    });
-
-    it('works when gh team slug used for auther', function() {
-      const author = 'bowser';
-      expect(identify_reviewers_by_author({ config, author })).to.have.members([ 'mario' ]);
     });
   });
 

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -147,7 +147,20 @@ describe('reviewer', function() {
     };
 
     const stub = sinon.stub(github, 'get_team_members');
-    stub.withArgs('koopa-troop').returns([ 'bowser', 'king-boo', 'goomboss' ]);
+    stub.withArgs('koopa-troop').returns([
+      {
+        login: 'bowser',
+        id: 1,
+      },
+      {
+        login: 'king-boo',
+        id: 2,
+      },
+      {
+        login: 'goomboss',
+        id: 3,
+      },
+    ]);
 
     it('returns nothing when config does not have a "per-author" key', function() {
       const author = 'THIS DOES NOT MATTER';

--- a/test/stubs/context.js
+++ b/test/stubs/context.js
@@ -24,7 +24,6 @@ class ContextStub {
     return {
       owner: 'necojackarc',
       repo: 'auto-request-review',
-      org: 'necojackarc',
     };
   }
 }


### PR DESCRIPTION
Revert Use team keys for authors (#88).

There are at least two bugs:

- It has to use `async` and `await` for API calls
- The way to fetch the `org` value seems incorrect