### PR TITLE
Request review from non-collaborators by mentioning them

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -146,6 +146,14 @@ async function assign_reviewers(reviewers) {
       pull_number: context.payload.pull_request.number,
     }
   );
+  const review_comments = await octokit.paginate(
+    octokit.pulls.listReviewComments,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+    }
+  );
   // Only consider mentions starting with the prefix
   const already_mentioned = new Set(review_list.filter((review) => (
     review.body.startsWith(comment_prefix)
@@ -158,9 +166,12 @@ async function assign_reviewers(reviewers) {
   ).reduce(
     (mentions, new_mentions) => mentions.concat(new_mentions), []
   ));
-  // Only consider top-level reviews
+  // Review and review comments
   const already_reviewed = new Set(review_list.filter(
     (review) => review.user !== null
+  ).map((review) => review.user.login));
+  const already_commented_review = new Set(review_comments.filter(
+    (review) => review.user.login !== null
   ).map((review) => review.user.login));
 
   const [ collaborators, non_collaborators ] = partition(
@@ -168,6 +179,7 @@ async function assign_reviewers(reviewers) {
       !review_requested.has(person)
       && !already_mentioned.has(person)
       && !already_reviewed.has(person)
+      && !already_commented_review.has(person)
       && person !== context.payload.pull_request.user.login
     )).map(
       async (person) => ({

--- a/src/github.js
+++ b/src/github.js
@@ -127,8 +127,49 @@ async function assign_reviewers(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
+  const comment_prefix = 'Auto-requesting reviews from non-collaborators: ';
+  const mention_prefix = '@';
+
+  const review_requested = new Set(await octokit.paginate(
+    octokit.pulls.listRequestedReviewers,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+    }
+  ));
+  const review_list = await octokit.paginate(
+    octokit.pulls.listReviews,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+    }
+  );
+  // Only consider mentions starting with the prefix
+  const already_mentioned = new Set(review_list.filter((review) => (
+    review.body.startsWith(comment_prefix)
+  )).map(
+    (review) => review.body.substring(comment_prefix.length).split(' ').filter(
+      (mention) => mention.startsWith(mention_prefix)
+    ).map(
+      (mention) => mention.substring(mention_prefix.length)
+    )
+  ).reduce(
+    (mentions, new_mentions) => mentions.concat(new_mentions), []
+  ));
+  // Only consider top-level reviews
+  const already_reviewed = new Set(review_list.filter(
+    (review) => review.user !== null
+  ).map((review) => review.user.login));
+
   const [ collaborators, non_collaborators ] = partition(
-    await Promise.all(individuals.map(
+    await Promise.all(individuals.filter((person) => (
+      !review_requested.has(person)
+      && !already_mentioned.has(person)
+      && !already_reviewed.has(person)
+      && person !== context.payload.pull_request.user.login
+    )).map(
       async (person) => ({
         person: person,
         status: await is_collaborator(person),
@@ -157,7 +198,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      body: 'Auto-requesting reviews from non-collaborators: ' + non_collaborators.map((person) => '@' + person).join(' '),
+      body: comment_prefix + non_collaborators.map((person) => mention_prefix + person).join(' '),
       event: 'COMMENT',
     });
 

--- a/src/github.js
+++ b/src/github.js
@@ -96,6 +96,30 @@ async function fetch_changed_files() {
   return changed_files;
 }
 
+async function is_collaborator(person) {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  return await octokit.repos.checkCollaborator({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    username: person,
+  }).then(
+    (response) => {
+      if (response.status === 204) {
+        return true;
+      }
+      return false;
+    },
+    (error) => {
+      if (error.status === 404) {
+        return false;
+      }
+      throw error;
+    }
+  );
+}
+
 async function assign_reviewers(reviewers) {
   const context = get_context();
   const octokit = get_octokit();
@@ -103,13 +127,44 @@ async function assign_reviewers(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  return octokit.pulls.requestReviewers({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number,
-    reviewers: individuals,
-    team_reviewers: teams,
-  });
+  const [ collaborators, non_collaborators ] = partition(
+    await Promise.all(individuals.map(
+      async (person) => ({
+        person: person,
+        status: await is_collaborator(person),
+      })
+    )),
+    ({ status }) => status
+  ).map(
+    (list) => list.map(
+      ({ person }) => person
+    )
+  );
+
+  const request_response = (collaborators.length === 0 && teams.length === 0)
+    ? null
+    : await octokit.pulls.requestReviewers({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+      reviewers: collaborators,
+      team_reviewers: teams,
+    });
+
+  const mention_response = non_collaborators.length === 0
+    ? null
+    : await octokit.pulls.createReview({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+      body: 'Auto-requesting reviews from non-collaborators: ' + non_collaborators.map((person) => '@' + person).join(' '),
+      event: 'COMMENT',
+    });
+
+  return {
+    request_response: request_response,
+    mention_response: mention_response,
+  };
 }
 
 /* Private */

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -134,6 +134,7 @@ describe('github', function() {
         createReview: mention_spy,
         listRequestedReviewers: sinon.spy(),
         listReviews: sinon.spy(),
+        listReviewComments: sinon.spy(),
       },
       repos: {
         checkCollaborator: collab_stub,
@@ -162,6 +163,11 @@ describe('github', function() {
         sinon.match.any
       );
       reviews_call.resolves([]);
+      const review_comments_call = paginate_stub.withArgs(
+        sinon.match.same(octokit.pulls.listReviewComments),
+        sinon.match.any
+      );
+      review_comments_call.resolves([]);
 
       const reviewers = [ 'mario', 'princess-peach', 'team:koopa-troop' ];
       await assign_reviewers(reviewers);
@@ -169,6 +175,7 @@ describe('github', function() {
       expect(collab_stub.calledTwice).to.be.true;
       expect(requests_call.calledOnce).to.be.true;
       expect(reviews_call.calledOnce).to.be.true;
+      expect(review_comments_call.calledOnce).to.be.true;
 
       expect(request_spy.calledOnce).to.be.true;
       expect(request_spy.lastCall.args[0]).to.deep.equal({
@@ -203,6 +210,12 @@ describe('github', function() {
           body: 'Auto-requesting reviews from non-collaborators: @yoshi',
           user: { login: 'bot' },
         },
+      ]);
+      const review_comments_call = paginate_stub.withArgs(
+        sinon.match.same(octokit.pulls.listReviewComments),
+        sinon.match.any
+      );
+      review_comments_call.resolves([
         {
           body: 'Looks good!',
           user: { login: 'princess-peach' },
@@ -215,6 +228,7 @@ describe('github', function() {
       expect(collab_stub.calledOnce).to.be.true;
       expect(requests_call.calledOnce).to.be.true;
       expect(reviews_call.calledOnce).to.be.true;
+      expect(review_comments_call.calledOnce).to.be.true;
 
       expect(request_spy.notCalled).to.be.true;
 


### PR DESCRIPTION
Fixes #98. Github restrict requested reviewers to people having write access to repos (collaborators), but people may actually want to request non-collaborators for review.

This change separates non-collaborators from collaborators and mention the non-collaborators with a review comment instead. To avoid repeatedly mentioning the same people, it now checks the review comments for people who already left a review or were pinged by the action and skip them along with the already requested reviewers when requesting new reviews. It also skips the PR author in case the author is not a collaborator.

A new test case is added to test the newly added functions. I also tested them in Qrox/Cataclysm-DDA#14 and Qrox/Cataclysm-DDA#15 (more detail in CleverRaven/Cataclysm-DDA#66072).