### PR TITLE
Bump to node.js v20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Github actions has now depricated node16.  Consider the update to node20.   Solves issue #116 

[GitHub blog post re: Node16 EoL transition plan](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/#:~:text=Node%2016%20has%20reached%20its,before%20finalizing%20the%20transition%20date.)