### PR TITLE
Remove suggestion that teams can be part of groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ reviewers:
     repository-owners:
       - me # username
       - you # username
-      - team:owners # GitHub team
     core-contributors:
       - good-boy # username
       - good-girl # username


### PR DESCRIPTION
It seems that this README suggestion was perhaps added in haste in #45 as I can't see any code that was added that would support looking "inside" a team to determine if the author is a member, and handle review requests appropriately based on that. See past reports that this is not working in #109